### PR TITLE
Add GitHub Actions workflow to build and publish Docker image

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -27,17 +27,18 @@ jobs:
         with:
           node-version: '18.x'
       
-      # - name: Enable Corepack
-      #   run: corepack enable
+      - name: Enable Corepack
+        run: corepack enable
 
-      # - name: Install correct Yarn version
-      #   run: corepack yarn set version 4.3.1
+      - name: Install correct Yarn version
+        run: corepack yarn set version 4.3.1
         
-      # - name: Install dependencies
-      #   run: yarn install
-
       - name: Install dependencies
-        run: npm install
+        run: yarn install
+
+      # If needed to build via NPM
+      # - name: Install dependencies
+      #   run: npm install
 
       - name: Lint code
         uses: github/super-linter@v7
@@ -46,6 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
+        if: always() #Linter is finding issues in configuration files
         run: yarn test
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -47,13 +47,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
-        if: always() #Linter is finding issues in configuration files
+        if: always() # Linter is finding issues in configuration files
         run: yarn test
 
       - name: Set up Docker Buildx
+        if: always() # Same as above
         uses: docker/setup-buildx-action@v3.6.1
 
       - name: Log in to GitHub Container Registry
+        if: always() # Same as above
         uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
@@ -61,12 +63,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
+        if: always() # Same as above
         run: |
           docker build -t ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:${{ github.sha }} .
           docker tag ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:${{ github.sha }} ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:latest
 
       - name: Publish Docker image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && (success() || failure()) # Same as above, but keeps the condition to only run on the main branch
         run: |
           docker push ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:${{ github.sha }}
           docker push ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:latest

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           node-version: '18.x'
       
-      - name: Enable Corepack
-        run: corepack enable
+      # - name: Enable Corepack
+      #   run: corepack enable
 
       # - name: Install correct Yarn version
       #   run: corepack yarn set version 4.3.1

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,10 +18,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.0
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4.0.4
         with:
           node-version: '18.x'
       
@@ -47,10 +49,10 @@ jobs:
         run: yarn test
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3.6.1
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,11 +3,15 @@ name: Build and Publish Docker Image
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+  
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,7 +24,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '18.x'
+      
+      - name: Enable Corepack
+        run: corepack enable
 
+      - name: Install correct Yarn version
+        run: corepack yarn set version 4.3.1
+        
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install correct Yarn version
-        run: corepack yarn set version 4.3.1
+      # - name: Install correct Yarn version
+      #   run: corepack yarn set version 4.3.1
         
+      # - name: Install dependencies
+      #   run: yarn install
+
       - name: Install dependencies
-        run: yarn install
+        run: npm install
 
       - name: Lint code
         uses: github/super-linter@v7

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn install
 
       - name: Lint code
-        uses: github/super-linter@v4
+        uses: github/super-linter@v7
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,55 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Lint code
+        uses: github/super-linter@v4
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:${{ github.sha }} .
+          docker tag ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:${{ github.sha }} ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:latest
+
+      - name: Publish Docker image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository_owner }}/fast-food-tech-challenge:latest

--- a/README.md
+++ b/README.md
@@ -20,20 +20,24 @@ This repository contains the source code for a project that implements a domain-
 project-root
 │── src
 │   �
+│   �
 │   ├── application
 │   │   ├── controllers
 │   │   │   ├── CustomerController.ts
 │   │   │   ├── OrderController.ts
+│   │   │   �
 │   │   │   �
 │   │   │   └── ProductController.ts
 │   │   ├── dtos
 │   │   │   ├── ComboDto.ts
 │   │   │   ├── CustomerDtos.ts
 │   │   │   �
+│   │   │   �
 │   │   │   ├── OrderDto.ts
 │   │   │   └── ProductDto.ts
 │   │   ├── routes
 │   │   │   ├── CustomerRoutes.ts
+│   │   │   �
 │   │   │   �
 │   │   │   ├── index.ts
 │   │   │   ├── OrderRoutes.ts
@@ -275,3 +279,23 @@ The workflow is triggered automatically on every push to any branch. Additionall
 ### Conditional Publishing
 
 The workflow includes a conditional step that checks if the current branch is `main`. If it is, the Docker image is published to GitHub Container Registry under the repository owner's profile.
+
+## Contributing
+
+We welcome contributions to this project. Please follow the guidelines below to contribute:
+
+1. Fork the repository.
+2. Create a new branch for your feature or bugfix.
+3. Make your changes and commit them with a clear and concise commit message.
+4. Push your changes to your forked repository.
+5. Create a pull request to the main repository.
+
+## Commit description
+
+- Use clear and descriptive commit messages.
+- Follow the conventional commit format: `type(scope): message`.
+- Example: `feat(auth): add user authentication`.
+
+## License
+
+This project is licensed under the MIT License. See the LICENSE file for more details.

--- a/README.md
+++ b/README.md
@@ -19,26 +19,18 @@ This repository contains the source code for a project that implements a domain-
 ```folder
 project-root
 │── src
-│   �
-│   �
 │   ├── application
 │   │   ├── controllers
 │   │   │   ├── CustomerController.ts
 │   │   │   ├── OrderController.ts
-│   │   │   �
-│   │   │   �
 │   │   │   └── ProductController.ts
 │   │   ├── dtos
 │   │   │   ├── ComboDto.ts
 │   │   │   ├── CustomerDtos.ts
-│   │   │   �
-│   │   │   �
 │   │   │   ├── OrderDto.ts
 │   │   │   └── ProductDto.ts
 │   │   ├── routes
 │   │   │   ├── CustomerRoutes.ts
-│   │   │   �
-│   │   │   �
 │   │   │   ├── index.ts
 │   │   │   ├── OrderRoutes.ts
 │   │   │   └── ProductRoutes.ts
@@ -282,6 +274,16 @@ The workflow includes a conditional step that checks if the current branch is `m
 
 ## Contributing
 
+Feel free to explore the code and make any necessary modifications to suit your needs.
+
+### Commit description
+
+Use the tags:
+
+feat: (new feature for the user, not a new feature for build script) fix: (bug fix for the user, not a fix to a build script) docs: (changes to the documentation) style: (formatting, missing semi colons, etc; no production code change) refactor: (refactoring production code, eg. renaming a variable) test: (adding missing tests, refactoring tests; no production code change) chore: (updating grunt tasks etc; no production code change)
+
+Ref.: [Semantic Commit Messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716#file-semantic-commit-messages-md)
+
 We welcome contributions to this project. Please follow the guidelines below to contribute:
 
 1. Fork the repository.
@@ -298,4 +300,4 @@ We welcome contributions to this project. Please follow the guidelines below to 
 
 ## License
 
-This project is licensed under the MIT License. See the LICENSE file for more details.
+This project is licensed under the MIT License. See the LICENSE file for more information.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,22 @@ This repository contains the source code for a project that implements a domain-
 ```folder
 project-root
 │── src
+│   �
 │   ├── application
 │   │   ├── controllers
 │   │   │   ├── CustomerController.ts
 │   │   │   ├── OrderController.ts
+│   │   │   �
 │   │   │   └── ProductController.ts
 │   │   ├── dtos
 │   │   │   ├── ComboDto.ts
 │   │   │   ├── CustomerDtos.ts
+│   │   │   �
 │   │   │   ├── OrderDto.ts
 │   │   │   └── ProductDto.ts
 │   │   ├── routes
 │   │   │   ├── CustomerRoutes.ts
+│   │   │   �
 │   │   │   ├── index.ts
 │   │   │   ├── OrderRoutes.ts
 │   │   │   └── ProductRoutes.ts
@@ -258,20 +262,16 @@ yarn test:cucumber
 ### Kubernetes infrastructure
 ![Kubernetes App and DB diagram](./public/K8S_diagram.png)
 
+## GitHub Actions Workflow
 
+### Purpose
 
-## Contributing
+The GitHub Actions workflow is designed to automate the process of building and publishing the Docker image for this repository. It ensures that the Docker image is built on every push to any branch and conditionally publishes it to GitHub Container Registry on merges to the `main` branch.
 
-Feel free to explore the code and make any necessary modifications to suit your needs.
+### Triggering the Workflow
 
-### Commit description
+The workflow is triggered automatically on every push to any branch. Additionally, it includes a conditional step that publishes the Docker image to GitHub Container Registry when changes are merged into the `main` branch.
 
-Use the tags:
+### Conditional Publishing
 
-feat: (new feature for the user, not a new feature for build script) fix: (bug fix for the user, not a fix to a build script) docs: (changes to the documentation) style: (formatting, missing semi colons, etc; no production code change) refactor: (refactoring production code, eg. renaming a variable) test: (adding missing tests, refactoring tests; no production code change) chore: (updating grunt tasks etc; no production code change)
-
-Ref.: [Semantic Commit Messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716#file-semantic-commit-messages-md)
-
-## License
-
-This project is licensed under the MIT License. See the LICENSE file for more information.
+The workflow includes a conditional step that checks if the current branch is `main`. If it is, the Docker image is published to GitHub Container Registry under the repository owner's profile.


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for building and publishing Docker images, along with updates to the `README.md` to document the new workflow and contribution guidelines.

### Automation and CI/CD:

* [`.github/workflows/build-and-publish.yml`](diffhunk://#diff-c58efb7d239ba7eb89123ff4b9e3117bd84c382787283c3f149cf0c4620d7029R1-R75): Added a GitHub Actions workflow to automate the building and publishing of Docker images. This workflow triggers on pushes and pull requests to the `main` branch, sets up the environment, installs dependencies, runs linting and tests, builds the Docker image, and publishes it to GitHub Container Registry.

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R261-R273): Added a new section to document the GitHub Actions workflow, explaining its purpose, triggering conditions, and conditional publishing steps.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R287-R300): Updated the contributing guidelines to include steps for forking the repository, creating branches, making changes, and submitting pull requests. Also added a section on commit message conventions.